### PR TITLE
feat: add walker

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,30 @@ for await (const node of parseHTMLStream(reader)) {
 ```
 
 This code snippet showcases how to iterate through the DOM Nodes in a streaming fashion, offering a practical approach for processing HTML streams in real-time.
+
+## Walker example
+
+If you prefer to have control over moving around the HTML tree of the stream, you can use the following function:
+
+```ts
+import htmlStreamWalker from "parse-html-stream/walker";
+
+// ...
+
+const reader = res.body.getReader();
+const walker = await htmlStreamWalker(reader);
+
+// Root node
+const rootNode = walker.rootNode 
+
+// Gives the firstChild taking account the stream chunks
+const child = await walker.firstChild(rootNode); 
+
+// Gives the nextSibling taking account the stream chunks
+const brother = await walker.nextSibling(rootNode); 
+
+// You can do it with every HTML node:
+const childOfBrother = await walker.firstChild(brother);
+```
+
+The stream is processed as you walk through the tree, whenever it does not find a `firstChild` or `nextSibling` and has not yet finished the stream, it asks for another chunk. This way you can walk through the tree during the stream.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-html-stream",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "module": "./build/index.js",
   "type": "module",
   "main": "./build/index.js",
@@ -12,14 +12,27 @@
   },
   "files": [
     "build",
-    "index.d.ts"
+    "index.d.ts",
+    "walker.d.ts"
   ],
+  "exports": {
+    ".": {
+      "import": "./build/index.js",
+      "require": "./build/index.js",
+      "types": "./index.d.ts"
+    },
+    "./walker": {
+      "import": "./build/walker/index.js",
+      "require": "./build/walker/index.js",
+      "types": "./walker.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/aralroca/parse-html-stream.git"
   },
   "scripts": {
-    "build": "bun build --minify --outdir=build src/index.ts",
+    "build": "bun build --minify --outdir=build src/index.ts src/walker/index.ts",
     "test": "bun test"
   },
   "devDependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,162 +6,158 @@ const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
 global.document = dom.window.document;
 global.window = dom.window;
 
-describe("utils", () => {
-  describe("rpc", () => {
-    describe("parse-html-stream", () => {
-      it("should handle an empty HTML stream", async () => {
-        const stream = new ReadableStream({
-          start(controller) {
-            controller.close();
-          },
-        });
-
-        const reader = stream.getReader();
-        const nodes = [];
-
-        const parseHTMLStream = await import(".").then((m) => m.default);
-
-        for await (const node of parseHTMLStream(reader)) {
-          nodes.push(node);
-        }
-
-        expect(nodes).toEqual([]);
-      });
-
-      it("should transform a stream of HTML into a stream of nodes", async () => {
-        const encoder = new TextEncoder();
-        const stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue(encoder.encode("<html>"));
-            controller.enqueue(encoder.encode("<head />"));
-            controller.enqueue(encoder.encode("<body>"));
-            controller.enqueue(encoder.encode('<div class="foo">Bar</div>'));
-            controller.enqueue(encoder.encode("</body>"));
-            controller.enqueue(encoder.encode("</html>"));
-            controller.close();
-          },
-        });
-
-        const reader = stream.getReader();
-        const nodeNames = [];
-
-        const parseHTMLStream = await import(".").then((m) => m.default);
-
-        for await (const node of parseHTMLStream(reader)) {
-          nodeNames.push(node?.nodeName);
-        }
-
-        expect(nodeNames).toEqual(["HTML", "HEAD", "BODY", "DIV", "#text"]);
-      });
-
-      it("should work with comments", async () => {
-        const encoder = new TextEncoder();
-        const stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue(encoder.encode("<html>"));
-            controller.enqueue(encoder.encode("<head />"));
-            controller.enqueue(encoder.encode("<body>"));
-            controller.enqueue(
-              encoder.encode('<div class="foo"><!-- comment -->Bar</div>'),
-            );
-            controller.enqueue(encoder.encode("</body>"));
-            controller.enqueue(encoder.encode("</html>"));
-            controller.close();
-          },
-        });
-
-        const reader = stream.getReader();
-        const nodeNames = [];
-
-        const parseHTMLStream = await import(".").then((m) => m.default);
-
-        for await (const node of parseHTMLStream(reader)) {
-          nodeNames.push(node?.nodeName);
-        }
-
-        expect(nodeNames).toEqual([
-          "HTML",
-          "HEAD",
-          "BODY",
-          "DIV",
-          "#comment",
-          "#text",
-        ]);
-      });
-
-      it("should be possible to read the attributes of a node HTMLElement", async () => {
-        const encoder = new TextEncoder();
-        const stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue(encoder.encode('<div class="foo">Bar</div>'));
-            controller.close();
-          },
-        });
-
-        const reader = stream.getReader();
-        const nodes: Node[] = [];
-
-        const parseHTMLStream = await import(".").then((m) => m.default);
-
-        for await (const node of parseHTMLStream(reader)) {
-          nodes.push(node);
-        }
-
-        expect(nodes).toHaveLength(5);
-        expect(nodes[0]?.nodeName).toBe("HTML");
-        expect(nodes[1]?.nodeName).toBe("HEAD");
-        expect(nodes[2]?.nodeName).toBe("BODY");
-        expect(nodes[3]?.nodeName).toBe("DIV");
-        expect(nodes[4]?.nodeName).toBe("#text");
-        expect((nodes[3] as HTMLElement).getAttribute("class")).toBe("foo");
-      });
-
-      it("should work with very nested HTML", async () => {
-        const encoder = new TextEncoder();
-        const stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue(encoder.encode("<html>"));
-            controller.enqueue(encoder.encode("<head />"));
-            controller.enqueue(encoder.encode("<body>"));
-            controller.enqueue(encoder.encode('<div class="foo">'));
-            controller.enqueue(encoder.encode('<div class="bar">'));
-            controller.enqueue(encoder.encode('<div class="baz">'));
-            controller.enqueue(encoder.encode('<div class="qux">'));
-            controller.enqueue(encoder.encode("Hello"));
-            controller.enqueue(encoder.encode("</div>"));
-            controller.enqueue(encoder.encode("</div>"));
-            controller.enqueue(encoder.encode("</div>"));
-            controller.enqueue(encoder.encode("</div>"));
-            controller.enqueue(encoder.encode("</body>"));
-            controller.enqueue(encoder.encode("</html>"));
-            controller.close();
-          },
-        });
-
-        const reader = stream.getReader();
-        const nodes = [];
-
-        const parseHTMLStream = await import(".").then((m) => m.default);
-
-        for await (const node of parseHTMLStream(reader)) {
-          nodes.push(node);
-        }
-
-        expect(nodes).toHaveLength(8);
-        expect(nodes[0]?.nodeName).toBe("HTML");
-        expect(nodes[1]?.nodeName).toBe("HEAD");
-        expect(nodes[2]?.nodeName).toBe("BODY");
-        expect(nodes[3]?.nodeName).toBe("DIV");
-        expect((nodes[3] as HTMLElement).classList.contains("foo")).toBeTrue();
-        expect(nodes[4]?.nodeName).toBe("DIV");
-        expect((nodes[4] as HTMLElement).classList.contains("bar")).toBeTrue();
-        expect(nodes[5]?.nodeName).toBe("DIV");
-        expect((nodes[5] as HTMLElement).classList.contains("baz")).toBeTrue();
-        expect(nodes[6]?.nodeName).toBe("DIV");
-        expect((nodes[6] as HTMLElement).classList.contains("qux")).toBeTrue();
-        expect(nodes[7]?.nodeName).toBe("#text");
-        expect(nodes[7]?.textContent).toBe("Hello");
-      });
+describe("parse-html-stream", () => {
+  it("should handle an empty HTML stream", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
     });
+
+    const reader = stream.getReader();
+    const nodes = [];
+
+    const parseHTMLStream = await import(".").then((m) => m.default);
+
+    for await (const node of parseHTMLStream(reader)) {
+      nodes.push(node);
+    }
+
+    expect(nodes).toEqual([]);
+  });
+
+  it("should transform a stream of HTML into a stream of nodes", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("<html>"));
+        controller.enqueue(encoder.encode("<head />"));
+        controller.enqueue(encoder.encode("<body>"));
+        controller.enqueue(encoder.encode('<div class="foo">Bar</div>'));
+        controller.enqueue(encoder.encode("</body>"));
+        controller.enqueue(encoder.encode("</html>"));
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+    const nodeNames = [];
+
+    const parseHTMLStream = await import(".").then((m) => m.default);
+
+    for await (const node of parseHTMLStream(reader)) {
+      nodeNames.push(node?.nodeName);
+    }
+
+    expect(nodeNames).toEqual(["HTML", "HEAD", "BODY", "DIV", "#text"]);
+  });
+
+  it("should work with comments", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("<html>"));
+        controller.enqueue(encoder.encode("<head />"));
+        controller.enqueue(encoder.encode("<body>"));
+        controller.enqueue(
+          encoder.encode('<div class="foo"><!-- comment -->Bar</div>'),
+        );
+        controller.enqueue(encoder.encode("</body>"));
+        controller.enqueue(encoder.encode("</html>"));
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+    const nodeNames = [];
+
+    const parseHTMLStream = await import(".").then((m) => m.default);
+
+    for await (const node of parseHTMLStream(reader)) {
+      nodeNames.push(node?.nodeName);
+    }
+
+    expect(nodeNames).toEqual([
+      "HTML",
+      "HEAD",
+      "BODY",
+      "DIV",
+      "#comment",
+      "#text",
+    ]);
+  });
+
+  it("should be possible to read the attributes of a node HTMLElement", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('<div class="foo">Bar</div>'));
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+    const nodes: Node[] = [];
+
+    const parseHTMLStream = await import(".").then((m) => m.default);
+
+    for await (const node of parseHTMLStream(reader)) {
+      nodes.push(node);
+    }
+
+    expect(nodes).toHaveLength(5);
+    expect(nodes[0]?.nodeName).toBe("HTML");
+    expect(nodes[1]?.nodeName).toBe("HEAD");
+    expect(nodes[2]?.nodeName).toBe("BODY");
+    expect(nodes[3]?.nodeName).toBe("DIV");
+    expect(nodes[4]?.nodeName).toBe("#text");
+    expect((nodes[3] as HTMLElement).getAttribute("class")).toBe("foo");
+  });
+
+  it("should work with very nested HTML", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("<html>"));
+        controller.enqueue(encoder.encode("<head />"));
+        controller.enqueue(encoder.encode("<body>"));
+        controller.enqueue(encoder.encode('<div class="foo">'));
+        controller.enqueue(encoder.encode('<div class="bar">'));
+        controller.enqueue(encoder.encode('<div class="baz">'));
+        controller.enqueue(encoder.encode('<div class="qux">'));
+        controller.enqueue(encoder.encode("Hello"));
+        controller.enqueue(encoder.encode("</div>"));
+        controller.enqueue(encoder.encode("</div>"));
+        controller.enqueue(encoder.encode("</div>"));
+        controller.enqueue(encoder.encode("</div>"));
+        controller.enqueue(encoder.encode("</body>"));
+        controller.enqueue(encoder.encode("</html>"));
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+    const nodes = [];
+
+    const parseHTMLStream = await import(".").then((m) => m.default);
+
+    for await (const node of parseHTMLStream(reader)) {
+      nodes.push(node);
+    }
+
+    expect(nodes).toHaveLength(8);
+    expect(nodes[0]?.nodeName).toBe("HTML");
+    expect(nodes[1]?.nodeName).toBe("HEAD");
+    expect(nodes[2]?.nodeName).toBe("BODY");
+    expect(nodes[3]?.nodeName).toBe("DIV");
+    expect((nodes[3] as HTMLElement).classList.contains("foo")).toBeTrue();
+    expect(nodes[4]?.nodeName).toBe("DIV");
+    expect((nodes[4] as HTMLElement).classList.contains("bar")).toBeTrue();
+    expect(nodes[5]?.nodeName).toBe("DIV");
+    expect((nodes[5] as HTMLElement).classList.contains("baz")).toBeTrue();
+    expect(nodes[6]?.nodeName).toBe("DIV");
+    expect((nodes[6] as HTMLElement).classList.contains("qux")).toBeTrue();
+    expect(nodes[7]?.nodeName).toBe("#text");
+    expect(nodes[7]?.textContent).toBe("Hello");
   });
 });

--- a/src/walker/index.test.ts
+++ b/src/walker/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "bun:test";
+import { JSDOM } from "jsdom";
+import htmlStreamWalker from ".";
+
+const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+global.document = dom.window.document;
+global.window = dom.window;
+
+describe("htmlStreamWalker", () => {
+  it("should handle an empty HTML stream", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+
+    const { rootNode } = await htmlStreamWalker(reader);
+
+    expect(rootNode).toBeEmpty();
+  });
+
+  it("should transform a stream of HTML into a stream of nodes", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("<html>"));
+        controller.enqueue(encoder.encode("<head />"));
+        controller.enqueue(encoder.encode("<body>"));
+        controller.enqueue(encoder.encode('<div class="foo">Bar</div>'));
+        controller.enqueue(encoder.encode("</body>"));
+        controller.enqueue(encoder.encode("</html>"));
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+
+    const { rootNode, firstChild, nextSibling } =
+      await htmlStreamWalker(reader);
+
+    expect(rootNode?.nodeName).toBe("HTML");
+
+    const child = await firstChild(rootNode!);
+    expect(child?.nodeName).toBe("HEAD");
+
+    const body = await nextSibling(child!);
+    expect(body?.nodeName).toBe("BODY");
+
+    const div = await firstChild(body!);
+    expect(div?.nodeName).toBe("DIV");
+
+    const text = await firstChild(div!);
+    expect(text?.nodeName).toBe("#text");
+    expect(text?.textContent).toBe("Bar");
+  });
+
+  it("should work with comments", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("<html>"));
+        controller.enqueue(encoder.encode("<head />"));
+        controller.enqueue(encoder.encode("<body>"));
+        controller.enqueue(
+          encoder.encode('<div class="foo"><!-- comment -->Bar</div>'),
+        );
+        controller.enqueue(encoder.encode("</body>"));
+        controller.enqueue(encoder.encode("</html>"));
+        controller.close();
+      },
+    });
+
+    const reader = stream.getReader();
+
+    const { rootNode, firstChild, nextSibling } =
+      await htmlStreamWalker(reader);
+
+    expect(rootNode?.nodeName).toBe("HTML");
+
+    const child = await firstChild(rootNode!);
+    expect(child?.nodeName).toBe("HEAD");
+
+    const body = await nextSibling(child!);
+    expect(body?.nodeName).toBe("BODY");
+
+    const div = await firstChild(body!);
+    expect(div?.nodeName).toBe("DIV");
+
+    const comment = await firstChild(div!);
+    expect(comment?.nodeName).toBe("#comment");
+
+    const text = await nextSibling(comment!);
+    expect(text?.nodeName).toBe("#text");
+    expect(text?.textContent).toBe("Bar");
+  });
+});

--- a/src/walker/index.ts
+++ b/src/walker/index.ts
@@ -1,0 +1,29 @@
+const decoder = new TextDecoder();
+const AUTOCREATED_NODE_NAMES = new Set(["HTML", "HEAD", "BODY"]);
+
+export default async function htmlStreamWalker(
+  streamReader: ReadableStreamDefaultReader<Uint8Array>,
+) {
+  const doc = document.implementation.createHTMLDocument();
+
+  async function waitNextChunk() {
+    const { done, value } = await streamReader.read();
+    if (!done) doc.write(decoder.decode(value));
+    return done;
+  }
+
+  const done = await waitNextChunk();
+  const rootNode = done ? null : doc.documentElement;
+
+  function next(field: 'firstChild' | 'nextSibling') {
+    return async (node: Node) => {
+      if (!node) return null;
+      if (AUTOCREATED_NODE_NAMES.has(node.nodeName)) await waitNextChunk();
+      if (!node[field]) await waitNextChunk();
+      if (node[field]) return node[field];
+      return null;
+    }
+  }
+
+  return { rootNode, firstChild: next('firstChild'), nextSibling: next('nextSibling') };
+}

--- a/walker.d.ts
+++ b/walker.d.ts
@@ -1,0 +1,7 @@
+export default async function htmlStreamWalker(
+  streamReader: ReadableStreamDefaultReader<Uint8Array>,
+): {
+  rootNode: Node | null;
+  firstChild: (node: Node) => Node | null;
+  nextSibling: (node: Node) => Node | null;
+}


### PR DESCRIPTION
I added a walker to have control over moving around the HTML tree of the stream, you can use the following function:

```ts
import htmlStreamWalker from "parse-html-stream/walker";

// ...

const reader = res.body.getReader();
const walker = await htmlStreamWalker(reader);

// Root node
const rootNode = walker.rootNode 

// Gives the firstChild taking account the stream chunks
const child = await walker.firstChild(rootNode); 

// Gives the nextSibling taking account the stream chunks
const brother = await walker.nextSibling(rootNode); 

// You can do it with every HTML node:
const childOfBrother = await walker.firstChild(brother);
```

The stream is processed as you walk through the tree, whenever it does not find a `firstChild` or `nextSibling` and has not yet finished the stream, it asks for another chunk. This way you can walk through the tree during the stream.